### PR TITLE
Add .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ check pep8 standards:
   script:
     - linter_errors=$(yapf --diff --recursive src/spiir | wc -l | xargs test 0 -eq)
     - echo "$linter_errors"
-    - if [ ! -z "$linter_errors" ]; then \
-        echo "Detected yapf formatting issues; please fix"; \
-        exit 1; else echo "Yapf formatting is correct"; \
-        exit 0; fi
+    - if [ ! -z "$linter_errors" ]; then
+      echo "Detected yapf formatting issues; please fix";
+      exit 1; else echo "Yapf formatting is correct";
+      exit 0; fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,9 @@ check pep8 standards:
     - /usr/local/bin/python -m pip install --upgrade pip
     - pip install yapf
   script:
-    - cd src/spiir
-    - linter_errors=$(git diff -U0 --no-color --relative origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME | yapf-diff --style pep8)
+    - linter_errors=yapf --diff --recursive src/spiir | wc -l | xargs test 0 -eq
     - echo "$linter_errors"
-    - if [ ! -z "$linter_errors" ]; then echo "Detected yapf formatting issues; please fix"; exit 1; else echo "Yapf formatting is correct"; exit 0; fi
+    - if [ ! -z "$linter_errors" ]; then \
+        echo "Detected yapf formatting issues; please fix"; \
+        exit 1; else echo "Yapf formatting is correct"; \
+        exit 0; fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ check pep8 standards:
     - /usr/local/bin/python -m pip install --upgrade pip
     - pip install yapf
   script:
-    - linter_errors=yapf --diff --recursive src/spiir | wc -l | xargs test 0 -eq
+    - linter_errors=$(yapf --diff --recursive src/spiir | wc -l | xargs test 0 -eq)
     - echo "$linter_errors"
     - if [ ! -z "$linter_errors" ]; then \
         echo "Detected yapf formatting issues; please fix"; \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,12 @@
+image: docker:20.10.14
+
+check pep8 standards:
+  image: python:3.10
+  before_script:
+    - /usr/local/bin/python -m pip install --upgrade pip
+    - pip install yapf
+  script:
+    - cd src/spiir
+    - linter_errors=$(git diff -U0 --no-color --relative origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME | yapf-diff --style pep8)
+    - echo "$linter_errors"
+    - if [ ! -z "$linter_errors" ]; then echo "Detected yapf formatting issues; please fix"; exit 1; else echo "Yapf formatting is correct"; exit 0; fi

--- a/src/spiir/p_astro/mass_contour/model.py
+++ b/src/spiir/p_astro/mass_contour/model.py
@@ -9,6 +9,7 @@ from .predict import calc_probabilities, predict_pastro, predict_redshift
 
 # Class based method for estimation
 class MassContourEstimator:
+
     def __init__(
         self,
         coefficients: dict[str, float],
@@ -106,9 +107,11 @@ class MassContourEstimator:
             if key not in valid_coeffs:
                 raise KeyError(f"{key} not in valid coeffs {valid_coeffs}")
             if not isinstance(coeffs[key], float):
-                raise TypeError(f"{key} type must be float, not {type(coeffs[key])}")
+                raise TypeError(
+                    f"{key} type must be float, not {type(coeffs[key])}")
         if not (0 < coeffs["m0"] < 1):
-            raise ValueError(f"m0 coeff should be within 0 and 1; m0 = {coeffs['m0']}")
+            raise ValueError(
+                f"m0 coeff should be within 0 and 1; m0 = {coeffs['m0']}")
 
         self._coefficients = coeffs
 
@@ -126,7 +129,8 @@ class MassContourEstimator:
 
         # predict redshift and mass uncertainties according to model coefficients
         mchirp_std = mchirp * self.coefficients["m0"]
-        z, z_std = predict_redshift(self.coefficients, snr, eff_dist, self._lal_cosmology, truncate_lower_dist)
+        z, z_std = predict_redshift(self.coefficients, snr, eff_dist,
+                                    self._lal_cosmology, truncate_lower_dist)
 
         # calculate class probabilities given mchirp and redshift uncertainty
         probabilities = calc_probabilities(
@@ -141,7 +145,8 @@ class MassContourEstimator:
 
         # plot paired figure plot
         fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=figsize)
-        _draw_mass_contour_axes(ax1, mchirp, mchirp_std, z, z_std, self._m_bounds, self._mgap_bounds)
+        _draw_mass_contour_axes(ax1, mchirp, mchirp_std, z, z_std,
+                                self._m_bounds, self._mgap_bounds)
         _draw_prob_pie_axes(ax2, probabilities)
 
         if suptitle:
@@ -195,5 +200,6 @@ class MassContourEstimator:
             truncate_lower_dist,
         )
 
-    def __call__(self, mchirp: float, snr: float, eff_dist: float) -> dict[str, float]:
+    def __call__(self, mchirp: float, snr: float,
+                 eff_dist: float) -> dict[str, float]:
         return self.predict(mchirp, snr, eff_dist)

--- a/src/spiir/p_astro/mass_contour/plot.py
+++ b/src/spiir/p_astro/mass_contour/plot.py
@@ -95,7 +95,8 @@ def _draw_mass_contour_axes(
         ax.plot((m1_max, m1_max), (mcm1_to_m2(mcs, lim_m1s), m1_max), "b")
     else:
         ax.plot(m1b, m2b, "b")
-        ax.plot((m1_max, m1_max), (mcm1_to_m2(mcs, lim_m1s), mcm1_to_m2(mcb, lim_m1b)), "b")
+        ax.plot((m1_max, m1_max),
+                (mcm1_to_m2(mcs, lim_m1s), mcm1_to_m2(mcb, lim_m1b)), "b")
     if mis >= m2_min:
         ax.plot(m1s, m2s, "b")
         ax.plot((lim_m1s, lim_m1b), (m2_min, m2_min), "b")
@@ -117,7 +118,10 @@ def _draw_mass_contour_axes(
         color=get_source_colour("NSBH"),
         alpha=0.5,
     )
-    ax.fill_between(np.arange(gap_max, m1_max, 0.01), 0.0, ns_max, color=get_source_colour("NSBH"))
+    ax.fill_between(np.arange(gap_max, m1_max, 0.01),
+                    0.0,
+                    ns_max,
+                    color=get_source_colour("NSBH"))
     ax.fill_between(
         np.arange(ns_max, gap_max, 0.01),
         np.arange(ns_max, gap_max, 0.01),
@@ -202,8 +206,8 @@ def _draw_mass_contour_axes(
 
 
 def plot_prob_pie_figure(
-    probabilities: dict[str, float],
-    figsize: tuple[float, float] = (8, 6),
+        probabilities: dict[str, float],
+        figsize: tuple[float, float] = (8, 6),
 ) -> Figure:
     fig, ax = plt.subplots(figsize=figsize)
     _draw_prob_pie_axes(ax, probabilities)

--- a/src/spiir/p_astro/mass_contour/predict.py
+++ b/src/spiir/p_astro/mass_contour/predict.py
@@ -7,7 +7,6 @@
 # Source: https://github.com/gwastro/pycbc/blob/master/pycbc/mchirp_area.py
 # Additional edits drawn from prior work done by V. Villa-Ortega:
 # https://github.com/veronica-villa/source_probabilities_estimation_pycbclive
-
 """Functions to compute the area corresponding to different CBC on the m1 & m2
 plane when given a central mchirp value and uncertainty.
 
@@ -77,7 +76,8 @@ def estimate_redshift_from_distance(
     return z_estimation, z_std_estimation
 
 
-def estimate_source_mass(mdet: float, mdet_std: float, z: float, z_std: float) -> tuple[float, float]:
+def estimate_source_mass(mdet: float, mdet_std: float, z: float,
+                         z_std: float) -> tuple[float, float]:
     """
     Takes values of redshift, redshift uncertainty, detector mass and its
     uncertainty and computes the source mass and its uncertainty.
@@ -100,7 +100,7 @@ def estimate_source_mass(mdet: float, mdet_std: float, z: float, z_std: float) -
 
     """
     msrc = mdet / (1.0 + z)  # source frame mass
-    msrc_std = msrc * ((mdet_std / mdet) ** 2.0 + (z_std / (1.0 + z)) ** 2.0) ** 0.5
+    msrc_std = msrc * ((mdet_std / mdet)**2.0 + (z_std / (1.0 + z))**2.0)**0.5
     return msrc, msrc_std
 
 
@@ -124,7 +124,10 @@ def integrate_chirp_mass(mchirp: float, m_min: float, m_max: float) -> float:
         The result of the integration of m2 over m1.
 
     """
-    return quad(lambda m, mchirp: mcm1_to_m2(mchirp, m), m_min, m_max, args=mchirp)[0]
+    return quad(lambda m, mchirp: mcm1_to_m2(mchirp, m),
+                m_min,
+                m_max,
+                args=mchirp)[0]
 
 
 def get_area(
@@ -162,7 +165,8 @@ def get_area(
     # type check inputs according to implemented logic
     if isinstance(lim_h1, str):
         assert lim_h1 == "diagonal", "if lim_h1 is a str it must be 'diagonal'."
-    assert isinstance(lim_h2, float), "get_area not compatible with lim_h2 as str."
+    assert isinstance(lim_h2,
+                      float), "get_area not compatible with lim_h2 as str."
 
     # get bounds of chirp mass contour given uncertainty
     mchirp_max = msrc + msrc_std
@@ -235,7 +239,8 @@ def calc_areas(
     # check valid input arguments for mass bounds [lower, upper]
     m_min, m_max = m_bounds
     mgap_min, mgap_max = mgap_bounds
-    assert (0 < m_min <= m_max) and (0 < mgap_min <= mgap_max)  # <1 not astrophysical
+    assert (0 < m_min <= m_max) and (0 < mgap_min <= mgap_max
+                                     )  # <1 not astrophysical
 
     # compute source frame chirp mass given detector frame mass and redshift
     mc_src, mc_src_std = estimate_source_mass(mchirp, mchirp_std, z, z_std)
@@ -244,7 +249,8 @@ def calc_areas(
     abbh = get_area(mc_src, mc_src_std, "diagonal", mgap_max, mgap_max, m_max)
     abhg = get_area(mc_src, mc_src_std, mgap_max, mgap_min, mgap_max, m_max)
     ansbh = get_area(mc_src, mc_src_std, mgap_min, m_min, mgap_max, m_max)
-    agg = get_area(mc_src, mc_src_std, "diagonal", mgap_min, mgap_min, mgap_max)
+    agg = get_area(mc_src, mc_src_std, "diagonal", mgap_min, mgap_min,
+                   mgap_max)
     agns = get_area(mc_src, mc_src_std, mgap_min, m_min, mgap_min, mgap_max)
     abns = get_area(mc_src, mc_src_std, "diagonal", m_min, m_min, mgap_min)
 
@@ -267,8 +273,11 @@ def predict_redshift(
     logger.debug(f"truncate_lower_dist: {truncate_lower_dist}")
     # compute estimated luminosity distance and redshift and their uncertainties
     dist_est = coefficients["a0"] * eff_distance
-    dist_std_est = dist_est * math.exp(coefficients["b0"]) * snr ** coefficients["b1"]
-    z, z_std = estimate_redshift_from_distance(dist_est, dist_std_est, truncate_lower_dist, lal_cosmology)
+    dist_std_est = dist_est * math.exp(
+        coefficients["b0"]) * snr**coefficients["b1"]
+    z, z_std = estimate_redshift_from_distance(dist_est, dist_std_est,
+                                               truncate_lower_dist,
+                                               lal_cosmology)
 
     return z, z_std
 
@@ -283,7 +292,8 @@ def calc_probabilities(
     group_mgap: bool = True,
 ) -> dict[str, float]:
     # determine chirp mass bounds in detector frame for classification
-    get_redshifted_mchirp = lambda m: (m / (2**0.2)) * (1 + z)  # Mc_det = (1+z)*Mc
+    get_redshifted_mchirp = lambda m: (m /
+                                       (2**0.2)) * (1 + z)  # Mc_det = (1+z)*Mc
     mchirp_min, mchirp_max = (get_redshifted_mchirp(m) for m in m_bounds)
 
     # determine astrophysical source class probabilities given estimated parameters
@@ -305,8 +315,10 @@ def calc_probabilities(
 
     else:
         # compute probabilities according to proportional areas in mass contour
-        mc_std = mchirp * coefficients["m0"]  # inherent uncertainty in chirp mass
-        areas = calc_areas(mchirp, mc_std, z, z_std, m_bounds, mgap_bounds, group_mgap)
+        mc_std = mchirp * coefficients[
+            "m0"]  # inherent uncertainty in chirp mass
+        areas = calc_areas(mchirp, mc_std, z, z_std, m_bounds, mgap_bounds,
+                           group_mgap)
         total_area = sum(areas.values())
         probabilities = {key: areas[key] / total_area for key in areas}
 
@@ -360,9 +372,11 @@ def predict_pastro(
         The astrophysical source probabilities for each class.
     """
     # predict redshift according to model coefficients
-    z, z_std = predict_redshift(coefficients, snr, eff_distance, lal_cosmology, truncate_lower_dist)
+    z, z_std = predict_redshift(coefficients, snr, eff_distance, lal_cosmology,
+                                truncate_lower_dist)
 
     # calculate class probabilities given mchirp and redshift uncertainty
-    probabilities = calc_probabilities(coefficients, mchirp, z, z_std, m_bounds, mgap_bounds, group_mgap)
+    probabilities = calc_probabilities(coefficients, mchirp, z, z_std,
+                                       m_bounds, mgap_bounds, group_mgap)
 
     return probabilities

--- a/src/spiir/p_astro/p_astro.py
+++ b/src/spiir/p_astro/p_astro.py
@@ -15,6 +15,7 @@ def compute_pastro(
         p_astro[label] = value
     return p_astro
 
+
 def update_posteriors():
     pass
 
@@ -61,7 +62,6 @@ def update_posteriors():
 #     lal_cosmology: bool
 #         If True, it uses the Planck15 cosmology model as defined in lalsuite instead of the astropy default.
 
-
 #     Returns
 #     -------
 #     p_astro : dictionary
@@ -79,11 +79,10 @@ def update_posteriors():
 #         lal_cosmology,
 #         truncate_lower_dist=0.003,
 #     )
-    
+
 #     a_hat_bns = probs["BNS"]
 #     a_hat_bbh = probs["BBH"]
 #     a_hat_nsbh = probs["NSBH"]
-
 
 #     # Compute category-wise Bayes factors
 #     # from astrophysical Bayes factor


### PR DESCRIPTION
Adds a .gitlab-ci.yml to do basic yapf Python formatting checks in the style of pep8 on any mirrored GitLab repository.